### PR TITLE
feature: 审计事件支持上报 scope_type 和 scope_id #22

### DIFF
--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/AuditClient.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/AuditClient.java
@@ -59,9 +59,10 @@ public class AuditClient {
 
             // 输出审计事件
             List<AuditEvent> auditEvents = currentAuditContext.getEvents();
-            if (CollectionUtils.isNotEmpty(auditEvents)) {
-                eventExporter.export(auditEvents);
+            if (CollectionUtils.isEmpty(auditEvents)) {
+                return;
             }
+            eventExporter.export(auditEvents);
         } finally {
             LazyAuditContextHolder.get().reset();
         }

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/DefaultAuditEventBuilder.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/DefaultAuditEventBuilder.java
@@ -41,13 +41,29 @@ public class DefaultAuditEventBuilder implements AuditEventBuilder {
                 Object originInstance = safeGetElement(originInstanceList, index);
                 Object instance = safeGetElement(instanceList, index);
                 Map<String, Object> attributes = buildMergedEventAttributes(instanceId, instanceName);
-                AuditEvent auditEvent = buildAuditEvent(instanceId, instanceName, originInstance, instance,
-                        attributes, actionAuditContext.getExtendData());
+                AuditEvent auditEvent = buildAuditEvent(
+                        instanceId,
+                        instanceName,
+                        originInstance,
+                        instance,
+                        attributes,
+                        actionAuditContext.getExtendData(),
+                        actionAuditContext.getScopeType(),
+                        actionAuditContext.getScopeId()
+                );
                 events.add(auditEvent);
             }
         } else {
-            AuditEvent auditEvent = buildAuditEvent(null, null, null, null,
-                    actionAuditContext.getAttributes(), actionAuditContext.getExtendData());
+            AuditEvent auditEvent = buildAuditEvent(
+                    null,
+                    null,
+                    null,
+                    null,
+                    actionAuditContext.getAttributes(),
+                    actionAuditContext.getExtendData(),
+                    actionAuditContext.getScopeType(),
+                    actionAuditContext.getScopeId()
+            );
             events.add(auditEvent);
         }
         return events;
@@ -69,12 +85,14 @@ public class DefaultAuditEventBuilder implements AuditEventBuilder {
         return list != null && list.size() > index ? list.get(index) : null;
     }
 
-    protected AuditEvent buildAuditEvent(String instanceId,
-                                         String instanceName,
-                                         Object originInstance,
-                                         Object instance,
-                                         Map<String, Object> attributes,
-                                         Map<String, Object> extendData) {
+    private AuditEvent buildAuditEvent(String instanceId,
+                                       String instanceName,
+                                       Object originInstance,
+                                       Object instance,
+                                       Map<String, Object> attributes,
+                                       Map<String, Object> extendData,
+                                       String scopeType,
+                                       String scopeId) {
         AuditEvent auditEvent = buildBasicAuditEvent();
 
         // 审计记录 - 原始数据
@@ -86,6 +104,8 @@ public class DefaultAuditEventBuilder implements AuditEventBuilder {
         auditEvent.setInstanceName(instanceName);
         auditEvent.setContent(resolveAttributes(actionAuditContext.getContent(), attributes));
         auditEvent.setExtendData(extendData);
+        auditEvent.setScopeType(scopeType);
+        auditEvent.setScopeId(scopeId);
         return auditEvent;
     }
 

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/ActionAuditContext.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/ActionAuditContext.java
@@ -140,4 +140,13 @@ public interface ActionAuditContext {
 
     Object getExtendDataValue(String key);
 
+    ActionAuditContext setScopeType(String scopeType);
+
+    ActionAuditContext setScopeId(String scopeType);
+
+    String getScopeType();
+
+    String getScopeId();
+
+
 }

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/ActionAuditContextBuilder.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/ActionAuditContextBuilder.java
@@ -50,6 +50,16 @@ public class ActionAuditContextBuilder {
      */
     private Map<String, Object> attributes = new HashMap<>();
 
+    /**
+     * 管理空间类型（比如 project/biz等）
+     */
+    private String scopeType;
+
+    /**
+     * 管理空间ID（比如项目ID、cmdb业务ID）
+     */
+    private String scopeId;
+
     public static ActionAuditContextBuilder builder(String actionId) {
         return new ActionAuditContextBuilder(actionId);
     }
@@ -127,8 +137,18 @@ public class ActionAuditContextBuilder {
         return this;
     }
 
+    public ActionAuditContextBuilder setScopeType(String scopeType) {
+        this.scopeType = scopeType;
+        return this;
+    }
+
+    public ActionAuditContextBuilder setScopeId(String scopeId) {
+        this.scopeId = scopeId;
+        return this;
+    }
+
     public ActionAuditContext build() {
         return new SdkActionAuditContext(actionId, resourceType, instanceIdList, instanceNameList,
-                originInstanceList, instanceList, content, eventBuilder, attributes);
+                originInstanceList, instanceList, content, eventBuilder, attributes, scopeType, scopeId);
     }
 }

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/InvalidActionAuditContext.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/InvalidActionAuditContext.java
@@ -152,4 +152,24 @@ public class InvalidActionAuditContext implements ActionAuditContext {
     public Object getExtendDataValue(String key) {
         return null;
     }
+
+    @Override
+    public ActionAuditContext setScopeType(String scopeType) {
+        return this;
+    }
+
+    @Override
+    public ActionAuditContext setScopeId(String scopeType) {
+        return this;
+    }
+
+    @Override
+    public String getScopeType() {
+        return null;
+    }
+
+    @Override
+    public String getScopeId() {
+        return null;
+    }
 }

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/SdkActionAuditContext.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/SdkActionAuditContext.java
@@ -81,6 +81,16 @@ public class SdkActionAuditContext implements ActionAuditContext {
      */
     private boolean disabled;
 
+    /**
+     * 管理空间类型（比如 project/biz等）
+     */
+    private String scopeType;
+
+    /**
+     * 管理空间ID（比如项目ID、cmdb业务ID）
+     */
+    private String scopeId;
+
     SdkActionAuditContext(String actionId,
                           String resourceType,
                           List<String> instanceIdList,
@@ -89,7 +99,9 @@ public class SdkActionAuditContext implements ActionAuditContext {
                           List<Object> instanceList,
                           String content,
                           Class<? extends AuditEventBuilder> eventBuilderClass,
-                          Map<String, Object> attributes) {
+                          Map<String, Object> attributes,
+                          String scopeType,
+                          String scopeId) {
         this.actionId = actionId;
         this.startTime = System.currentTimeMillis();
         this.resourceType = resourceType;
@@ -100,6 +112,8 @@ public class SdkActionAuditContext implements ActionAuditContext {
         this.content = content;
         this.eventBuilderClass = eventBuilderClass == null ? DefaultAuditEventBuilder.class : eventBuilderClass;
         this.attributes = (attributes == null ? new HashMap<>() : attributes);
+        this.scopeType = scopeType;
+        this.scopeId = scopeId;
     }
 
     @Override
@@ -292,6 +306,28 @@ public class SdkActionAuditContext implements ActionAuditContext {
     }
 
     @Override
+    public ActionAuditContext setScopeType(String scopeType) {
+        this.scopeType = scopeType;
+        return this;
+    }
+
+    @Override
+    public ActionAuditContext setScopeId(String scopeId) {
+        this.scopeId = scopeId;
+        return this;
+    }
+
+    @Override
+    public String getScopeType() {
+        return this.scopeType;
+    }
+
+    @Override
+    public String getScopeId() {
+        return this.scopeId;
+    }
+
+    @Override
     public String toString() {
         return new StringJoiner(", ", SdkActionAuditContext.class.getSimpleName() + "[", "]")
                 .add("actionId='" + actionId + "'")
@@ -308,6 +344,8 @@ public class SdkActionAuditContext implements ActionAuditContext {
                 .add("events=" + events)
                 .add("disabled=" + disabled)
                 .add("extendData=" + extendData)
+                .add("scopeType=" + scopeType)
+                .add("scopeId=" + scopeId)
                 .toString();
     }
 }

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/SdkAuditContext.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/SdkAuditContext.java
@@ -4,9 +4,12 @@ import com.tencent.bk.audit.constants.AccessTypeEnum;
 import com.tencent.bk.audit.constants.AuditEventKey;
 import com.tencent.bk.audit.constants.Constants;
 import com.tencent.bk.audit.constants.UserIdentifyTypeEnum;
+import com.tencent.bk.audit.filter.AuditPostFilter;
+import com.tencent.bk.audit.filter.AuditPostFilters;
 import com.tencent.bk.audit.model.AuditEvent;
 import com.tencent.bk.audit.model.AuditHttpRequest;
 import com.tencent.bk.audit.utils.EventIdGenerator;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
@@ -111,6 +114,10 @@ public class SdkAuditContext implements AuditContext {
     public void end() {
         this.endTime = System.currentTimeMillis();
         buildAuditEvents();
+        List<AuditPostFilter> filters = AuditPostFilters.getFilters();
+        if (CollectionUtils.isNotEmpty(filters)) {
+            filters.forEach(filter -> this.events.forEach(filter::map));
+        }
     }
 
     private void buildAuditEvents() {

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/filter/AuditPostFilter.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/filter/AuditPostFilter.java
@@ -1,0 +1,18 @@
+package com.tencent.bk.audit.filter;
+
+import com.tencent.bk.audit.model.AuditEvent;
+
+/**
+ * 审计结束之前触发的 Filter，允许修改最终的审计事件。
+ */
+public interface AuditPostFilter {
+    /**
+     * 修改审计事件
+     *
+     * @param auditEvent 审计事件
+     * @return 修改之后的审计事件
+     */
+    default AuditEvent map(AuditEvent auditEvent) {
+        return auditEvent;
+    }
+}

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/filter/AuditPostFilters.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/filter/AuditPostFilters.java
@@ -1,0 +1,24 @@
+package com.tencent.bk.audit.filter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AuditPostFilter 管理
+ */
+@Slf4j
+public class AuditPostFilters {
+    private static final List<AuditPostFilter> filters = new ArrayList<>();
+
+    public static void addFilter(AuditPostFilter filter) {
+        log.info("Add AuditPostFilter: {}", filter);
+        filters.add(filter);
+    }
+
+    public static List<AuditPostFilter> getFilters() {
+        return filters;
+    }
+
+}

--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/model/AuditEvent.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/model/AuditEvent.java
@@ -28,7 +28,7 @@ public class AuditEvent {
     @JsonProperty("event_content")
     private String content;
 
-    /**
+    /** 6；lL2
      * 请求ID
      */
     @JsonProperty("request_id")
@@ -150,6 +150,17 @@ public class AuditEvent {
 
     @JsonProperty("audit_event_signature")
     private String auditEventSignature = Constants.AUDIT_EVENT_SIGNATURE;
+    /**
+     * 管理空间类型（比如 project/biz等）
+     */
+    @JsonProperty("scope_type")
+    private String scopeType;
+
+    /**
+     * 管理空间ID（比如项目ID、cmdb业务ID）
+     */
+    @JsonProperty("scope_id")
+    private String scopeId;
 
     public AuditEvent() {
     }

--- a/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/AuditPostFilterExample.java
+++ b/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/AuditPostFilterExample.java
@@ -5,18 +5,28 @@ import com.tencent.bk.audit.constants.AccessTypeEnum;
 import com.tencent.bk.audit.constants.UserIdentifyTypeEnum;
 import com.tencent.bk.audit.context.ActionAuditContext;
 import com.tencent.bk.audit.context.AuditContext;
+import com.tencent.bk.audit.filter.AuditPostFilter;
+import com.tencent.bk.audit.filter.AuditPostFilters;
+import com.tencent.bk.audit.model.AuditEvent;
 
 import static com.tencent.bk.audit.constants.AuditAttributeNames.INSTANCE_ID;
 import static com.tencent.bk.audit.constants.AuditAttributeNames.INSTANCE_NAME;
 
 /**
- * 一次操作（请求）产生一个审计事件
+ * AuditPostFilter 的使用
  */
-public class SingleAuditEventExample {
+public class AuditPostFilterExample {
     private final AuditClient auditClient;
 
-    public SingleAuditEventExample(AuditClient auditClient) {
+    public AuditPostFilterExample(AuditClient auditClient) {
         this.auditClient = auditClient;
+        AuditPostFilters.addFilter(new AuditPostFilter() {
+            @Override
+            public AuditEvent map(AuditEvent auditEvent) {
+                auditEvent.addExtendData("test", "AuditPostFilterTest");
+                return auditEvent;
+            }
+        });
     }
 
     public void run() {
@@ -41,8 +51,6 @@ public class SingleAuditEventExample {
                 .setInstanceId("1000")
                 .setInstanceName("test_audit_execute_job_plan")
                 .setContent("Execute job plan [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})")
-                .setScopeType("biz")
-                .setScopeId("2")
                 .build()
                 .wrapActionRunnable(() -> {
                     // action code

--- a/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/DisableActionAuditContextExample.java
+++ b/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/DisableActionAuditContextExample.java
@@ -41,6 +41,8 @@ public class DisableActionAuditContextExample {
                 .setInstanceId("1000")
                 .setInstanceName("test_audit_execute_job_plan")
                 .setContent("Execute job plan [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})")
+                .setScopeType("biz")
+                .setScopeId("2")
                 .build()
                 .wrapActionRunnable(() -> {
                     // action code

--- a/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/MultiAuditEventExample.java
+++ b/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/MultiAuditEventExample.java
@@ -44,6 +44,8 @@ public class MultiAuditEventExample {
                 .setInstanceIdList(Arrays.asList("1000", "1001"))
                 .setInstanceNameList(Arrays.asList("plan1", "plan2"))
                 .setContent("Edit job plan [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})")
+                .setScopeType("biz")
+                .setScopeId("2")
                 .build()
                 .wrapActionRunnable(() -> {
                     //  action code

--- a/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/SubAuditEventExample.java
+++ b/bk-audit-java-sdk/src/test/java/com/tencent/bk/audit/example/SubAuditEventExample.java
@@ -51,6 +51,8 @@ public class SubAuditEventExample {
                 .setInstanceId("1000")
                 .setInstanceName("job_template_1")
                 .setContent("Delete job template [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})")
+                .setScopeType("biz")
+                .setScopeId("2")
                 .build()
                 .wrapActionRunnable(() -> {
                     //  action code
@@ -66,6 +68,8 @@ public class SubAuditEventExample {
                 .setInstanceIdList(Arrays.asList("1001", "1002"))
                 .setInstanceNameList(Arrays.asList("plan1", "plan2"))
                 .setContent("Delete job plan [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})")
+                .setScopeType("biz")
+                .setScopeId("2")
                 .build()
                 .wrapActionRunnable(() -> {
                     //  action code

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -527,6 +527,21 @@ public class JobExecuteService {
 }
 ```
 
+#### AuditPostFilter
+如果需要在审计结束之前修改审计事件内容，可以自定义 com.tencent.bk.audit.filter.AuditPostFilter 并声明为 Spring Component.
+
+```
+@Component
+public class CustomAuditPostFilter implements AuditPostFilter {
+
+    @Override
+    public AuditEvent map(AuditEvent auditEvent) {
+        // 对于生成的审计事件，添加自定义的扩展数据
+        auditEvent.addExtendData("test", "SpringBootAuditPostFilterTest");
+        return auditEvent;
+    }
+}
+```
 
 
 ## 示例代码

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # SDK 版本号
-version=1.0.7-SNAPSHOT
+version=1.0.8-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/ActionAuditAspect.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/ActionAuditAspect.java
@@ -149,6 +149,12 @@ public class ActionAuditAspect {
                 auditActionContext.addAttribute(auditAttribute.name(), value);
             }
         }
+        if (StringUtils.isNotEmpty(record.scopeType())) {
+            auditActionContext.setScopeType(parseBySpel(evaluationContext, record.scopeType()).toString());
+        }
+        if (StringUtils.isNotEmpty(record.scopeId())) {
+            auditActionContext.setScopeId((parseBySpel(evaluationContext, record.scopeId())).toString());
+        }
     }
 
     private void parseInstanceIdList(ActionAuditRecord record,

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/AuditApplicationRunner.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/AuditApplicationRunner.java
@@ -1,0 +1,44 @@
+package com.tencent.bk.audit;
+
+import com.tencent.bk.audit.filter.AuditPostFilter;
+import com.tencent.bk.audit.filter.AuditPostFilters;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.MapUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 审计SDK初始化
+ */
+@Slf4j
+public class AuditApplicationRunner implements ApplicationRunner, ApplicationContextAware {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("AuditApplicationRunner start");
+        Map<String, AuditPostFilter> auditPostFilterMap =
+                applicationContext.getBeansOfType(AuditPostFilter.class);
+        if (MapUtils.isEmpty(auditPostFilterMap)) {
+            return;
+        }
+        List<AuditPostFilter> filters = new ArrayList<>(auditPostFilterMap.values());
+        AnnotationAwareOrderComparator.sort(filters);
+        filters.forEach(AuditPostFilters::addFilter);
+        log.info("AuditApplicationRunner run success");
+    }
+}

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/AuditAspect.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/AuditAspect.java
@@ -36,7 +36,8 @@ public class AuditAspect {
     public AuditAspect(AuditClient auditClient,
                        AuditRequestProvider auditRequestProvider,
                        AuditExceptionResolver auditExceptionResolver,
-                       AuditProperties auditProperties, AuditMetrics auditMetrics) {
+                       AuditProperties auditProperties,
+                       AuditMetrics auditMetrics) {
         this.auditClient = auditClient;
         this.auditRequestProvider = auditRequestProvider;
         this.auditExceptionResolver = auditExceptionResolver;

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/annotations/ActionAuditRecord.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/annotations/ActionAuditRecord.java
@@ -38,4 +38,14 @@ public @interface ActionAuditRecord {
      * 自定义审计事件Builder
      */
     Class<? extends AuditEventBuilder> builder() default DefaultAuditEventBuilder.class;
+
+    /**
+     * 管理空间类型（比如 project/biz等） - SpEL表达式
+     */
+    String scopeType() default "";
+
+    /**
+     * 管理空间ID（比如项目ID、cmdb业务ID） - SpEL表达式
+     */
+    String scopeId() default "";
 }

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/config/AuditAutoConfiguration.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/config/AuditAutoConfiguration.java
@@ -4,6 +4,7 @@ import com.tencent.bk.audit.*;
 import com.tencent.bk.audit.constants.ExporterTypeEnum;
 import com.tencent.bk.audit.exporter.EventExporter;
 import com.tencent.bk.audit.exporter.LogFileEventExporter;
+import com.tencent.bk.audit.filter.AuditPostFilters;
 import com.tencent.bk.audit.metrics.AuditMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -73,5 +74,10 @@ public class AuditAutoConfiguration {
     @Bean
     public AuditMetrics auditMetrics(ObjectProvider<MeterRegistry> meterRegistryObjectProvider) {
         return new AuditMetrics(meterRegistryObjectProvider.getIfAvailable());
+    }
+
+    @Bean
+    public AuditApplicationRunner auditApplicationRunner() {
+        return new AuditApplicationRunner();
     }
 }

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/CustomAuditPostFilter.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/CustomAuditPostFilter.java
@@ -1,0 +1,15 @@
+package com.tencent.bk.audit;
+
+import com.tencent.bk.audit.filter.AuditPostFilter;
+import com.tencent.bk.audit.model.AuditEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuditPostFilter implements AuditPostFilter {
+
+    @Override
+    public AuditEvent map(AuditEvent auditEvent) {
+        auditEvent.addExtendData("test", "SpringBootAuditPostFilterTest");
+        return auditEvent;
+    }
+}

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/controller/AuditTestController.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/controller/AuditTestController.java
@@ -38,21 +38,29 @@ public class AuditTestController {
                     instanceIds = "#templateId",
                     instanceNames = "#$?.name"
             ),
+            scopeType = "#scopeType",
+            scopeId = "#scopeId",
             content = "View job template [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})"
     )
-    @GetMapping("/getJobTemplateById/template/{templateId}")
-    public JobTemplate getJobTemplateById(@PathVariable("templateId") Long templateId) {
-        return jobTemplateService.getTemplateById(templateId);
+    @GetMapping("/scope/{scopeType}/{scopeId}/template/{templateId}")
+    public JobTemplate getJobTemplateById(
+            @PathVariable("scopeType") String scopeType,
+            @PathVariable("scopeId") String scopeId,
+            @PathVariable("templateId") Long templateId) {
+        return jobTemplateService.getTemplateById(Long.valueOf(scopeId), templateId);
     }
 
     @AuditEntry(
             actionId = "create_job_template"
     )
-    @PostMapping("/createJobTemplate")
-    public JobTemplate createJobTemplate(@AuditRequestBody
-                                         @RequestBody
-                                                 CreateJobTemplateRequest request) {
-        return jobTemplateService.createJobTemplate(request.getName(), request.getDescription());
+    @PostMapping("/scope/{scopeType}/{scopeId}/template")
+    public JobTemplate createJobTemplate(
+            @PathVariable("scopeType") String scopeType,
+            @PathVariable("scopeId") String scopeId,
+            @AuditRequestBody
+            @RequestBody
+                    CreateJobTemplateRequest request) {
+        return jobTemplateService.createJobTemplate(Long.valueOf(scopeId), request.getName(), request.getDescription());
     }
 
     /**
@@ -64,9 +72,12 @@ public class AuditTestController {
             actionId = "delete_job_template",
             subActionIds = "delete_job_plan"
     )
-    @DeleteMapping("/deleteJobTemplate/template/{templateId}")
-    public void deleteJobTemplate(@PathVariable("templateId") Long templateId) {
-        jobTemplateService.deleteJobTemplate(templateId);
+    @DeleteMapping("/scope/{scopeType}/{scopeId}/template/{templateId}")
+    public void deleteJobTemplate(
+            @PathVariable("scopeType") String scopeType,
+            @PathVariable("scopeId") String scopeId,
+            @PathVariable("templateId") Long templateId) {
+        jobTemplateService.deleteJobTemplate(Long.valueOf(scopeId), templateId);
     }
 
 

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/model/JobPlan.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/model/JobPlan.java
@@ -1,8 +1,21 @@
 package com.tencent.bk.audit.model;
 
+/**
+ * 作业执行方案
+ */
 public class JobPlan {
+    /**
+     * ID
+     */
     private Long id;
+    /**
+     * 执行方案名称
+     */
     private String name;
+    /**
+     * CMDB 业务 ID
+     */
+    private Long bizId;
 
     public Long getId() {
         return id;
@@ -18,5 +31,13 @@ public class JobPlan {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Long getBizId() {
+        return bizId;
+    }
+
+    public void setBizId(Long bizId) {
+        this.bizId = bizId;
     }
 }

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/model/JobTemplate.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/model/JobTemplate.java
@@ -1,8 +1,24 @@
 package com.tencent.bk.audit.model;
 
+/**
+ * 作业模版
+ */
 public class JobTemplate {
+    /**
+     * ID
+     */
     private Long id;
+    /**
+     * CMDB 业务 ID
+     */
+    private Long bizId;
+    /**
+     * 名称
+     */
     private String name;
+    /**
+     * 描述
+     */
     private String description;
 
     public Long getId() {
@@ -27,5 +43,13 @@ public class JobTemplate {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public Long getBizId() {
+        return bizId;
+    }
+
+    public void setBizId(Long bizId) {
+        this.bizId = bizId;
     }
 }

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/service/JobPlanService.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/service/JobPlanService.java
@@ -17,10 +17,11 @@ import static com.tencent.bk.audit.constants.AuditAttributeNames.INSTANCE_NAME;
 @Service
 public class JobPlanService {
 
-    public JobPlan getPlanById(long planId) {
+    public JobPlan getPlanById(Long bizId, long planId) {
         JobPlan plan = new JobPlan();
         plan.setId(planId);
         plan.setName(buildPlanName(planId));
+        plan.setBizId(bizId);
         return plan;
     }
 
@@ -49,10 +50,12 @@ public class JobPlanService {
                     instanceIds = "#planId",
                     instanceNames = "#$?.name"
             ),
+            scopeType = "'biz'",
+            scopeId = "#bizId",
             content = "Delete job plan [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})"
     )
-    public JobPlan deleteJobPlan(Long planId) {
-        JobPlan jobPlan = getPlanById(planId);
+    public JobPlan deleteJobPlan(Long bizId, Long planId) {
+        JobPlan jobPlan = getPlanById(bizId, planId);
         // delete plan code here
         return jobPlan;
     }

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/service/JobTemplateService.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/service/JobTemplateService.java
@@ -27,8 +27,9 @@ public class JobTemplateService {
         this.jobPlanService = jobPlanService;
     }
 
-    public JobTemplate getTemplateById(long templateId) {
+    public JobTemplate getTemplateById(Long bizId, long templateId) {
         JobTemplate template = new JobTemplate();
+        template.setBizId(bizId);
         template.setId(templateId);
         template.setName(buildTemplateName(templateId));
         template.setDescription("job_template_desc_" + templateId);
@@ -46,14 +47,17 @@ public class JobTemplateService {
                     instanceIds = "#$?.id",
                     instanceNames = "#$?.name"
             ),
+            scopeType = "'biz'",
+            scopeId = "#bizId",
             content = "Create job template [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})"
     )
-    public JobTemplate createJobTemplate(String templateName, String templateDesc) {
+    public JobTemplate createJobTemplate(Long bizId, String templateName, String templateDesc) {
         JobTemplate template = new JobTemplate();
         long templateId = Math.abs(random.nextLong());
         template.setId(templateId);
         template.setName(templateName);
         template.setDescription(templateDesc);
+        template.setBizId(bizId);
         return template;
     }
 
@@ -64,17 +68,19 @@ public class JobTemplateService {
                     instanceIds = "#templateId",
                     instanceNames = "#$?.name"
             ),
+            scopeType = "'biz'",
+            scopeId = "#bizId",
             content = "Delete job template [{{" + INSTANCE_NAME + "}}]({{" + INSTANCE_ID + "}})"
     )
-    public JobTemplate deleteJobTemplate(Long templateId) {
-        JobTemplate jobTemplate = getTemplateById(templateId);
-        deleteJobPlansByTemplateId(templateId);
+    public JobTemplate deleteJobTemplate(Long bizId, Long templateId) {
+        JobTemplate jobTemplate = getTemplateById(bizId, templateId);
+        deleteJobPlansByTemplateId(bizId, templateId);
         return jobTemplate;
     }
 
-    private void deleteJobPlansByTemplateId(long templateId) {
+    private void deleteJobPlansByTemplateId(Long bizId, long templateId) {
         List<JobPlan> planList = jobPlanService.getPlanByTemplateId(templateId);
-        planList.forEach(plan -> jobPlanService.deleteJobPlan(plan.getId()));
+        planList.forEach(plan -> jobPlanService.deleteJobPlan(bizId, plan.getId()));
     }
 
 


### PR DESCRIPTION
1. sdk 支持添加 scope_type + scope_id 标准字段
2. 实现 AuditPostFilter 机制，用于全局修改审计事件的属性（可以通过AuditPostFilter来全局设置 scope_type+scope_id,无需在每一个审计事件重复声明)