### PR TITLE
fix: 程序启动时并发输出审计事件报错 #35

### DIFF
--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/utils/json/JsonUtils.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/utils/json/JsonUtils.java
@@ -3,8 +3,8 @@ package com.tencent.bk.audit.utils.json;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * JSON工具
@@ -12,7 +12,7 @@ import java.util.Map;
 @Slf4j
 public class JsonUtils {
 
-    private static final Map<String, JsonMapper> JSON_MAPPERS = new HashMap<>();
+    private static final Map<String, JsonMapper> JSON_MAPPERS = new ConcurrentHashMap<>();
 
     /**
      * 从Json串中解析成bean对象,支持参数泛型

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # SDK 版本号
-version=1.0.8
+version=1.0.9
 
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
1.JsonUtils中Mapper缓存使用ConcurrentHashMap。