### PR TITLE
perf: 安全加固 #41

### DIFF
--- a/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/SdkAuditContext.java
+++ b/bk-audit-java-sdk/src/main/java/com/tencent/bk/audit/context/SdkAuditContext.java
@@ -170,7 +170,7 @@ public class SdkAuditContext implements AuditContext {
 
         auditEvent.setUsername(username);
         if (userIdentifyType != null) {
-            auditEvent.setUserIdentifyType(UserIdentifyTypeEnum.PERSONAL.getValue());
+            auditEvent.setUserIdentifyType(userIdentifyType.getValue());
         }
         auditEvent.setUserIdentifyTenantId(userIdentifyTenantId);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # SDK 版本号
-version=2.0.2
+version=2.0.3-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # SDK 版本号
-version=2.0.3-SNAPSHOT
+version=2.0.3
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/ActionAuditAspect.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/ActionAuditAspect.java
@@ -237,7 +237,7 @@ public class ActionAuditAspect {
         // 通过 DataBindingMethodResolver 允许实例方法调用（如 getter、业务方法），
         // 但该 resolver 会自动屏蔽对 Class 类方法（如 forName、getMethod）的调用，阻断反射链攻击。
         SimpleEvaluationContext context = SimpleEvaluationContext
-            .forReadWriteDataBinding()
+            .forReadOnlyDataBinding()
             .withMethodResolvers(DataBindingMethodResolver.forInstanceMethodInvocation())
             .build();
 

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/ActionAuditAspect.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/ActionAuditAspect.java
@@ -17,7 +17,8 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.expression.spel.support.DataBindingMethodResolver;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
 import org.springframework.util.StopWatch;
 
 import java.lang.reflect.Method;
@@ -231,7 +232,15 @@ public class ActionAuditAspect {
     }
 
     private EvaluationContext buildEvaluationContext(JoinPoint jp, Method method, Object returnValue) {
-        EvaluationContext context = new StandardEvaluationContext();
+        // 使用 SimpleEvaluationContext 替代 StandardEvaluationContext，
+        // 禁用类型引用(T())、构造器(new)和静态方法调用，防止 SpEL 注入风险。
+        // 通过 DataBindingMethodResolver 允许实例方法调用（如 getter、业务方法），
+        // 但该 resolver 会自动屏蔽对 Class 类方法（如 forName、getMethod）的调用，阻断反射链攻击。
+        SimpleEvaluationContext context = SimpleEvaluationContext
+            .forReadWriteDataBinding()
+            .withMethodResolvers(DataBindingMethodResolver.forInstanceMethodInvocation())
+            .build();
+
         // 获取方法参数名，并设置方法参数到EvaluationContext
         String[] parameterNames = parameterNameDiscoverer.getParameterNames(method);
         if (parameterNames != null && parameterNames.length > 0) {

--- a/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/DefaultAuditRequestProvider.java
+++ b/spring-boot-bk-audit-starter/src/main/java/com/tencent/bk/audit/DefaultAuditRequestProvider.java
@@ -10,18 +10,13 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.UUID;
-
 /**
- * 默认的 AuditRequestProvider 实现。可以通过继承 DefaultAuditRequestProvider 自定义 AuditRequestProvider
+ * 默认的 AuditRequestProvider 实现，无真实有效审计字段。
+ * 请通过继承DefaultAuditRequestProvider或直接实现AuditRequestProvider接口来提供相应的审计字段，
+ * 从请求中读取数据作为审计字段时，需要注意数据是否真实可信，防止客户端伪造。
  */
 @Slf4j
 public class DefaultAuditRequestProvider implements AuditRequestProvider {
-    public static final String HEADER_USERNAME = "X-Username";
-    public static final String HEADER_USER_IDENTIFY_TENANT_ID = "X-User-Identify-Tenant-Id";
-    public static final String HEADER_USER_IDENTIFY_TYPE = "X-User-Identify-Type";
-    public static final String HEADER_ACCESS_TYPE = "X-Access-Type";
-    public static final String HEADER_REQUEST_ID = "X-Request-Id";
 
     @Override
     public AuditHttpRequest getRequest() {
@@ -40,53 +35,36 @@ public class DefaultAuditRequestProvider implements AuditRequestProvider {
 
     @Override
     public String getUsername() {
-        HttpServletRequest httpServletRequest = getHttpServletRequest();
-        return httpServletRequest.getHeader(HEADER_USERNAME);
+        return "";
     }
 
     @Override
     public UserIdentifyTypeEnum getUserIdentifyType() {
-        HttpServletRequest httpServletRequest = getHttpServletRequest();
-        return UserIdentifyTypeEnum.valOf(httpServletRequest.getHeader(HEADER_USER_IDENTIFY_TYPE));
+        return UserIdentifyTypeEnum.UNKNOWN;
     }
 
     @Override
     public String getUserIdentifyTenantId() {
-        HttpServletRequest httpServletRequest = getHttpServletRequest();
-        return httpServletRequest.getHeader(HEADER_USER_IDENTIFY_TENANT_ID);
+        return "";
     }
 
     @Override
     public AccessTypeEnum getAccessType() {
-        HttpServletRequest httpServletRequest = getHttpServletRequest();
-        return AccessTypeEnum.valOf(httpServletRequest.getHeader(HEADER_ACCESS_TYPE));
+        return AccessTypeEnum.OTHER;
     }
 
     @Override
     public String getRequestId() {
-        try {
-            HttpServletRequest httpServletRequest = getHttpServletRequest();
-            return httpServletRequest.getHeader(HEADER_REQUEST_ID);
-        } catch (Throwable e) {
-            log.error("Get request id error", e);
-            return UUID.randomUUID().toString().replace("-", "");
-        }
+        return "";
     }
 
     @Override
     public String getClientIp() {
-        HttpServletRequest request = getHttpServletRequest();
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff == null) {
-            return request.getRemoteAddr();
-        } else {
-            return xff.contains(",") ? xff.split(",")[0] : xff;
-        }
+        return "";
     }
 
     @Override
     public String getUserAgent() {
-        HttpServletRequest request = getHttpServletRequest();
-        return request.getHeader("User-Agent");
+        return "";
     }
 }

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/AuditSpringBootTest.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/AuditSpringBootTest.java
@@ -3,7 +3,6 @@ package com.tencent.bk.audit;
 import com.tencent.bk.audit.constants.AccessTypeEnum;
 import com.tencent.bk.audit.constants.Constants;
 import com.tencent.bk.audit.constants.UserIdentifyTypeEnum;
-import com.tencent.bk.audit.exception.NotFoundException;
 import com.tencent.bk.audit.exporter.EventExporter;
 import com.tencent.bk.audit.model.*;
 import com.tencent.bk.audit.utils.json.JsonUtils;
@@ -23,11 +22,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -56,19 +53,23 @@ public class AuditSpringBootTest {
         Mockito.reset(eventExporter);
     }
 
+    /**
+     * 校验 DefaultAuditRequestProvider 返回的默认值在审计事件中的体现
+     */
+    private void assertDefaultProviderFields(AuditEvent auditEvent) {
+        assertEquals("", auditEvent.getUsername());
+        assertEquals(UserIdentifyTypeEnum.UNKNOWN.getValue(), auditEvent.getUserIdentifyType());
+        assertEquals("", auditEvent.getRequestId());
+        assertEquals("", auditEvent.getAccessSourceIp());
+        assertEquals("", auditEvent.getAccessUserAgent());
+        assertEquals(AccessTypeEnum.OTHER.getValue(), auditEvent.getAccessType());
+    }
+
     @Test
     @DisplayName("审计操作 - 基础测试案例1")
     public void testSimpleAudit1() throws Exception {
-        String requestId = UUID.randomUUID().toString();
         this.mockMvc.perform(
-                get("/test/audit/action/scope/biz/2/template/1")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler")
-                        .header(DefaultAuditRequestProvider.HEADER_REQUEST_ID, requestId)
-                        .header(DefaultAuditRequestProvider.HEADER_ACCESS_TYPE, AccessTypeEnum.WEB.getValue())
-                        .header(DefaultAuditRequestProvider.HEADER_USER_IDENTIFY_TYPE,
-                                UserIdentifyTypeEnum.PERSONAL.getValue())
-                        .header("User-Agent", "Chrome")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler"))
+                get("/test/audit/action/scope/biz/2/template/1"))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<Collection<AuditEvent>> argument = ArgumentCaptor.forClass(Collection.class);
@@ -86,12 +87,7 @@ public class AuditSpringBootTest {
         assertEquals("job_template", auditEvent.getResourceTypeId());
         assertEquals("1", auditEvent.getInstanceId());
         assertEquals("job_template_1", auditEvent.getInstanceName());
-        assertEquals(requestId, auditEvent.getRequestId());
-        assertEquals("tyler", auditEvent.getUsername());
-        assertEquals(UserIdentifyTypeEnum.PERSONAL.getValue(), auditEvent.getUserIdentifyType());
-        assertNotNull(auditEvent.getAccessSourceIp());
-        assertEquals("Chrome", auditEvent.getAccessUserAgent());
-        assertEquals(AccessTypeEnum.WEB.getValue(), auditEvent.getAccessType());
+        assertDefaultProviderFields(auditEvent);
         assertEquals("View job template [job_template_1](1)", auditEvent.getContent());
         assertEquals("bk_audit_event", auditEvent.getAuditEventSignature());
         assertEquals(Constants.RESULT_CODE_SUCCESS, auditEvent.getResultCode());
@@ -105,21 +101,13 @@ public class AuditSpringBootTest {
     @Test
     @DisplayName("审计操作 - 基础测试案例2")
     public void testSimpleAudit2() throws Exception {
-        String requestId = UUID.randomUUID().toString();
         CreateJobTemplateRequest request = new CreateJobTemplateRequest();
         request.setName("test_audit_create_job_template");
         request.setDescription("test_audit_create_job_template_desc");
         MvcResult mockResult = this.mockMvc.perform(
                 post("/test/audit/action/scope/biz/2/template")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(JsonUtils.toJson(request))
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler")
-                        .header(DefaultAuditRequestProvider.HEADER_REQUEST_ID, requestId)
-                        .header(DefaultAuditRequestProvider.HEADER_ACCESS_TYPE, AccessTypeEnum.WEB.getValue())
-                        .header(DefaultAuditRequestProvider.HEADER_USER_IDENTIFY_TYPE,
-                                UserIdentifyTypeEnum.PERSONAL.getValue())
-                        .header("User-Agent", "Chrome")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler"))
+                        .content(JsonUtils.toJson(request)))
                 .andExpect(status().isOk())
                 .andReturn();
         JobTemplate createdJobTemplate = JsonUtils.fromJson(
@@ -140,12 +128,7 @@ public class AuditSpringBootTest {
         assertEquals("job_template", auditEvent.getResourceTypeId());
         assertEquals(String.valueOf(createdJobTemplate.getId()), auditEvent.getInstanceId());
         assertEquals("test_audit_create_job_template", auditEvent.getInstanceName());
-        assertEquals(requestId, auditEvent.getRequestId());
-        assertEquals("tyler", auditEvent.getUsername());
-        assertEquals(UserIdentifyTypeEnum.PERSONAL.getValue(), auditEvent.getUserIdentifyType());
-        assertNotNull(auditEvent.getAccessSourceIp());
-        assertEquals("Chrome", auditEvent.getAccessUserAgent());
-        assertEquals(AccessTypeEnum.WEB.getValue(), auditEvent.getAccessType());
+        assertDefaultProviderFields(auditEvent);
         assertEquals(
                 "Create job template [test_audit_create_job_template](" + createdJobTemplate.getId() + ")",
                 auditEvent.getContent());
@@ -156,25 +139,15 @@ public class AuditSpringBootTest {
         assertNotNull(auditEvent.getEndTime());
         assertEquals("biz", auditEvent.getScopeType());
         assertEquals("2", auditEvent.getScopeId());
-
-
     }
 
 
     @Test
     @DisplayName("审计操作 - 测试一次请求包含多个操作")
     public void testAuditMultiAction() throws Exception {
-        String requestId = UUID.randomUUID().toString();
         this.mockMvc.perform(
                 delete("/test/audit/action/scope/biz/2/template/1000")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler")
-                        .header(DefaultAuditRequestProvider.HEADER_REQUEST_ID, requestId)
-                        .header(DefaultAuditRequestProvider.HEADER_ACCESS_TYPE, AccessTypeEnum.WEB.getValue())
-                        .header(DefaultAuditRequestProvider.HEADER_USER_IDENTIFY_TYPE,
-                                UserIdentifyTypeEnum.PERSONAL.getValue())
-                        .header("User-Agent", "Chrome")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler"))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -218,12 +191,7 @@ public class AuditSpringBootTest {
             assertEquals(Constants.RESULT_SUCCESS_DESC, auditEvent.getResultContent());
             assertNotNull(auditEvent.getStartTime());
             assertNotNull(auditEvent.getEndTime());
-            assertEquals(requestId, auditEvent.getRequestId());
-            assertEquals("tyler", auditEvent.getUsername());
-            assertEquals(UserIdentifyTypeEnum.PERSONAL.getValue(), auditEvent.getUserIdentifyType());
-            assertNotNull(auditEvent.getAccessSourceIp());
-            assertEquals("Chrome", auditEvent.getAccessUserAgent());
-            assertEquals(AccessTypeEnum.WEB.getValue(), auditEvent.getAccessType());
+            assertDefaultProviderFields(auditEvent);
             assertEquals("biz", auditEvent.getScopeType());
             assertEquals("2", auditEvent.getScopeId());
         });
@@ -232,7 +200,6 @@ public class AuditSpringBootTest {
     @Test
     @DisplayName("审计操作 - 测试自定义审计事件生成")
     public void testCustomAuditEventBuilder() throws Exception {
-        String requestId = UUID.randomUUID().toString();
         ExecuteScriptRequest request = new ExecuteScriptRequest();
         request.setScriptId(1000L);
         List<Host> hosts = new ArrayList<>(2);
@@ -242,14 +209,7 @@ public class AuditSpringBootTest {
         this.mockMvc.perform(
                 post("/test/audit/action/executeScript")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(JsonUtils.toJson(request))
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler")
-                        .header(DefaultAuditRequestProvider.HEADER_REQUEST_ID, requestId)
-                        .header(DefaultAuditRequestProvider.HEADER_ACCESS_TYPE, AccessTypeEnum.WEB.getValue())
-                        .header(DefaultAuditRequestProvider.HEADER_USER_IDENTIFY_TYPE,
-                                UserIdentifyTypeEnum.PERSONAL.getValue())
-                        .header("User-Agent", "Chrome")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler"))
+                        .content(JsonUtils.toJson(request)))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -268,12 +228,7 @@ public class AuditSpringBootTest {
         assertEquals("host", auditEvent.getResourceTypeId());
         assertEquals("1,2", auditEvent.getInstanceId());
         assertEquals("127.0.0.1,127.0.0.2", auditEvent.getInstanceName());
-        assertEquals(requestId, auditEvent.getRequestId());
-        assertEquals("tyler", auditEvent.getUsername());
-        assertEquals(UserIdentifyTypeEnum.PERSONAL.getValue(), auditEvent.getUserIdentifyType());
-        assertNotNull(auditEvent.getAccessSourceIp());
-        assertEquals("Chrome", auditEvent.getAccessUserAgent());
-        assertEquals(AccessTypeEnum.WEB.getValue(), auditEvent.getAccessType());
+        assertDefaultProviderFields(auditEvent);
         assertEquals("Execute script [script_1000](1000)", auditEvent.getContent());
         assertEquals("bk_audit_event", auditEvent.getAuditEventSignature());
         assertEquals(Constants.RESULT_CODE_SUCCESS, auditEvent.getResultCode());
@@ -285,16 +240,8 @@ public class AuditSpringBootTest {
     @Test
     @DisplayName("测试 AuditPostFilter 自动注册并生效")
     public void testAuditPostFilter() throws Exception {
-        String requestId = UUID.randomUUID().toString();
         this.mockMvc.perform(
-                get("/test/audit/action/scope/biz/2/template/1")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler")
-                        .header(DefaultAuditRequestProvider.HEADER_REQUEST_ID, requestId)
-                        .header(DefaultAuditRequestProvider.HEADER_ACCESS_TYPE, AccessTypeEnum.WEB.getValue())
-                        .header(DefaultAuditRequestProvider.HEADER_USER_IDENTIFY_TYPE,
-                                UserIdentifyTypeEnum.PERSONAL.getValue())
-                        .header("User-Agent", "Chrome")
-                        .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler"))
+                get("/test/audit/action/scope/biz/2/template/1"))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<Collection<AuditEvent>> argument = ArgumentCaptor.forClass(Collection.class);
@@ -312,12 +259,7 @@ public class AuditSpringBootTest {
         assertEquals("job_template", auditEvent.getResourceTypeId());
         assertEquals("1", auditEvent.getInstanceId());
         assertEquals("job_template_1", auditEvent.getInstanceName());
-        assertEquals(requestId, auditEvent.getRequestId());
-        assertEquals("tyler", auditEvent.getUsername());
-        assertEquals(UserIdentifyTypeEnum.PERSONAL.getValue(), auditEvent.getUserIdentifyType());
-        assertNotNull(auditEvent.getAccessSourceIp());
-        assertEquals("Chrome", auditEvent.getAccessUserAgent());
-        assertEquals(AccessTypeEnum.WEB.getValue(), auditEvent.getAccessType());
+        assertDefaultProviderFields(auditEvent);
         assertEquals("View job template [job_template_1](1)", auditEvent.getContent());
         assertEquals("bk_audit_event", auditEvent.getAuditEventSignature());
         assertEquals(Constants.RESULT_CODE_SUCCESS, auditEvent.getResultCode());
@@ -330,19 +272,13 @@ public class AuditSpringBootTest {
 
     @Test
     @DisplayName("审计操作 - 测试业务异常不会被审计框架捕获")
-    public void testDoNotCatchBusinessException() {
-        String requestId = UUID.randomUUID().toString();
-        assertThatThrownBy(() -> {
-            this.mockMvc.perform(
-                    //  传入 templateId=0, 触发业务的 NotFoundException
-                    get("/test/audit/action/scope/biz/2/template/0")
-                            .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler")
-                            .header(DefaultAuditRequestProvider.HEADER_REQUEST_ID, requestId)
-                            .header(DefaultAuditRequestProvider.HEADER_ACCESS_TYPE, AccessTypeEnum.WEB.getValue())
-                            .header(DefaultAuditRequestProvider.HEADER_USER_IDENTIFY_TYPE,
-                                    UserIdentifyTypeEnum.PERSONAL.getValue())
-                            .header("User-Agent", "Chrome")
-                            .header(DefaultAuditRequestProvider.HEADER_USERNAME, "tyler"));
-        }).getCause().isInstanceOf(NotFoundException.class);
+    public void testDoNotCatchBusinessException() throws Exception {
+        // 传入 templateId=0, 触发业务的 NotFoundException，由 ExceptionControllerAdvise 处理返回 404
+        this.mockMvc.perform(
+                get("/test/audit/action/scope/biz/2/template/0"))
+                .andExpect(status().isNotFound());
+
+        // 业务异常场景下，审计框架导出异常审计事件
+        verify(eventExporter).export(anyList());
     }
 }

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/SpelInjectionSecurityTest.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/SpelInjectionSecurityTest.java
@@ -135,12 +135,12 @@ public class SpelInjectionSecurityTest {
     // =====================================================
 
     /**
-     * 构建与 ActionAuditAspect 修复后一致的 SimpleEvaluationContext (forReadWriteDataBinding + DataBindingMethodResolver)。
-     * 允许变量引用、属性读写和实例方法调用，但禁用 T()、new、静态方法和反射链。
+     * 构建与 ActionAuditAspect 修复后一致的 SimpleEvaluationContext (forReadOnlyDataBinding + DataBindingMethodResolver)。
+     * 允许变量引用、属性读和实例方法调用，但禁用 T()、new、静态方法和反射链。
      */
     private SimpleEvaluationContext buildSafeContext() {
         SimpleEvaluationContext context = SimpleEvaluationContext
-                .forReadWriteDataBinding()
+                .forReadOnlyDataBinding()
                 .withMethodResolvers(DataBindingMethodResolver.forInstanceMethodInvocation())
                 .build();
         context.setVariable("param", "normalValue");
@@ -228,7 +228,7 @@ public class SpelInjectionSecurityTest {
     }
 
     // =====================================================
-    // 第四组：forReadWriteDataBinding 场景下的方法调用验证
+    // 第四组：forReadOnlyDataBinding 场景下的方法调用验证
     // 验证允许对象方法调用（get/非get），同时高危操作仍被阻止
     // =====================================================
 
@@ -344,10 +344,10 @@ public class SpelInjectionSecurityTest {
         assertEquals("1001", result);
     }
 
-    // --- 4.4 forReadWriteDataBinding 下高危操作仍被阻止 ---
+    // --- 4.4 forReadOnlyDataBinding 下高危操作仍被阻止 ---
 
     @Test
-    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝 T() 类型引用")
+    @DisplayName("[方法调用-安全] forReadOnlyDataBinding 仍然拒绝 T() 类型引用")
     void testReadWriteContext_StillBlocksTypeReference() {
         SimpleEvaluationContext safeContext = buildSafeContext();
 
@@ -357,7 +357,7 @@ public class SpelInjectionSecurityTest {
     }
 
     @Test
-    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝 new 构造器")
+    @DisplayName("[方法调用-安全] forReadOnlyDataBinding 仍然拒绝 new 构造器")
     void testReadWriteContext_StillBlocksConstructor() {
         SimpleEvaluationContext safeContext = buildSafeContext();
 
@@ -367,7 +367,7 @@ public class SpelInjectionSecurityTest {
     }
 
     @Test
-    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝 getClass() 反射链")
+    @DisplayName("[方法调用-安全] forReadOnlyDataBinding 仍然拒绝 getClass() 反射链")
     void testReadWriteContext_StillBlocksGetClassReflection() {
         SimpleEvaluationContext safeContext = buildSafeContext();
 
@@ -378,7 +378,7 @@ public class SpelInjectionSecurityTest {
     }
 
     @Test
-    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝通过 String.getClass() 反射")
+    @DisplayName("[方法调用-安全] forReadOnlyDataBinding 仍然拒绝通过 String.getClass() 反射")
     void testReadWriteContext_StillBlocksStringGetClassReflection() {
         SimpleEvaluationContext safeContext = buildSafeContext();
 

--- a/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/SpelInjectionSecurityTest.java
+++ b/spring-boot-bk-audit-starter/src/test/java/com/tencent/bk/audit/SpelInjectionSecurityTest.java
@@ -1,0 +1,389 @@
+package com.tencent.bk.audit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.DataBindingMethodResolver;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * SpEL 注入安全测试。
+ * <p>
+ * 对应安全扫描报告：
+ * - Deserialization (P0): 反序列化/SpEL 注入
+ * - Command Injection (P1): SpEL 注入/任意方法调用
+ * - Template Injection (P0): AOP 审计注解参数 SpEL 表达式注入
+ * <p>
+ * 本测试用例演示：
+ * 1. 使用 StandardEvaluationContext（修复前）时，恶意 SpEL 可以执行 RCE
+ * 2. 使用 SimpleEvaluationContext（修复后）时，恶意 SpEL 会被安全拦截，但允许对象方法调用
+ */
+public class SpelInjectionSecurityTest {
+
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    /**
+     * 模拟业务 DTO，用于测试方法调用场景
+     */
+    public static class MockResource {
+        private final Long id;
+        private final String name;
+        private final List<String> tags;
+
+        public MockResource(Long id, String name, List<String> tags) {
+            this.id = id;
+            this.name = name;
+            this.tags = tags;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        /** 非 get 开头的业务方法：将名称转为大写 */
+        public String toUpperName() {
+            return name != null ? name.toUpperCase() : null;
+        }
+
+        /** 非 get 开头的业务方法：拼接展示文本 */
+        public String formatDisplay(String prefix) {
+            return prefix + "[" + name + "](" + id + ")";
+        }
+
+        /** 非 get 开头的业务方法：判断是否包含某个 tag */
+        public boolean containsTag(String tag) {
+            return tags != null && tags.contains(tag);
+        }
+
+        /** 非 get 开头的业务方法：返回 tag 数量 */
+        public int countTags() {
+            return tags != null ? tags.size() : 0;
+        }
+    }
+
+    // =====================================================
+    // 第一组：使用 StandardEvaluationContext（修复前的危险行为）
+    // 证明 RCE 漏洞确实存在
+    // =====================================================
+
+    @Test
+    @DisplayName("[修复前-漏洞复现] StandardEvaluationContext 允许通过 T() 调用 Runtime.exec 实现 RCE")
+    void testStandardContext_RCE_via_Runtime() {
+        // 模拟攻击者注入的恶意 SpEL 表达式：通过 T() 引用 Runtime 类并调用 exec
+        String maliciousSpel = "T(java.lang.Runtime).getRuntime().exec('calc')";
+
+        StandardEvaluationContext unsafeContext = new StandardEvaluationContext();
+        unsafeContext.setVariable("param", "normalValue");
+
+        // 使用 StandardEvaluationContext 时，恶意表达式可以成功执行（返回 Process 对象）
+        Object result = parser.parseExpression(maliciousSpel).getValue(unsafeContext);
+        assertNotNull(result, "StandardEvaluationContext 允许 T(Runtime).exec() 执行，返回了 Process 对象");
+        assertTrue(result instanceof Process, "返回值是 Process 实例，说明 RCE 成功");
+
+        // 清理：销毁启动的进程
+        ((Process) result).destroy();
+    }
+
+    @Test
+    @DisplayName("[修复前-漏洞复现] StandardEvaluationContext 允许读取系统环境变量")
+    void testStandardContext_ReadEnvVariable() {
+        // 攻击者可以读取敏感环境变量
+        String maliciousSpel = "T(java.lang.System).getenv('PATH')";
+
+        StandardEvaluationContext unsafeContext = new StandardEvaluationContext();
+
+        Object result = parser.parseExpression(maliciousSpel).getValue(unsafeContext);
+        assertNotNull(result, "StandardEvaluationContext 允许读取系统环境变量");
+        assertTrue(result.toString().length() > 0, "成功读取到 PATH 环境变量内容");
+    }
+
+    @Test
+    @DisplayName("[修复前-漏洞复现] StandardEvaluationContext 允许通过 new 创建对象并执行命令")
+    void testStandardContext_RCE_via_ProcessBuilder() {
+        // 使用 ProcessBuilder 构造命令执行
+        String maliciousSpel = "new java.lang.ProcessBuilder({'cmd', '/c', 'echo', 'hacked'}).start()";
+
+        StandardEvaluationContext unsafeContext = new StandardEvaluationContext();
+
+        Object result = parser.parseExpression(maliciousSpel).getValue(unsafeContext);
+        assertNotNull(result, "StandardEvaluationContext 允许 new ProcessBuilder().start() 执行");
+        assertTrue(result instanceof Process, "返回值是 Process 实例，说明通过构造器执行命令成功");
+
+        // 清理
+        ((Process) result).destroy();
+    }
+
+    // =====================================================
+    // 第二组：使用 SimpleEvaluationContext（修复后的安全行为）
+    // 证明修复有效，恶意 SpEL 全部被拒绝
+    // =====================================================
+
+    /**
+     * 构建与 ActionAuditAspect 修复后一致的 SimpleEvaluationContext (forReadWriteDataBinding + DataBindingMethodResolver)。
+     * 允许变量引用、属性读写和实例方法调用，但禁用 T()、new、静态方法和反射链。
+     */
+    private SimpleEvaluationContext buildSafeContext() {
+        SimpleEvaluationContext context = SimpleEvaluationContext
+                .forReadWriteDataBinding()
+                .withMethodResolvers(DataBindingMethodResolver.forInstanceMethodInvocation())
+                .build();
+        context.setVariable("param", "normalValue");
+        context.setVariable("$", "returnValue");
+        context.setVariable("resource", new MockResource(
+                1001L, "test_template",
+                Arrays.asList("production", "critical", "v2")));
+        context.setVariable("resources", Arrays.asList(
+                new MockResource(1L, "res_a", Arrays.asList("tagA")),
+                new MockResource(2L, "res_b", Arrays.asList("tagB")),
+                new MockResource(3L, "res_c", Arrays.asList("tagA", "tagC"))));
+        return context;
+    }
+
+    @Test
+    @DisplayName("[修复后-安全验证] SimpleEvaluationContext 拒绝 T() 类型引用，阻止 RCE")
+    void testSimpleContext_BlocksTypeReference() {
+        String maliciousSpel = "T(java.lang.Runtime).getRuntime().exec('calc')";
+        EvaluationContext safeContext = buildSafeContext();
+
+        // SimpleEvaluationContext 不支持 T() 类型引用，会抛出 SpelEvaluationException
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression(maliciousSpel).getValue(safeContext);
+        }, "SimpleEvaluationContext 应拒绝 T() 类型引用");
+    }
+
+    @Test
+    @DisplayName("[修复后-安全验证] SimpleEvaluationContext 拒绝读取系统环境变量")
+    void testSimpleContext_BlocksSystemEnvAccess() {
+        String maliciousSpel = "T(java.lang.System).getenv('PATH')";
+        EvaluationContext safeContext = buildSafeContext();
+
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression(maliciousSpel).getValue(safeContext);
+        }, "SimpleEvaluationContext 应拒绝 T(System).getenv() 调用");
+    }
+
+    @Test
+    @DisplayName("[修复后-安全验证] SimpleEvaluationContext 拒绝 new 构造器调用")
+    void testSimpleContext_BlocksConstructor() {
+        String maliciousSpel = "new java.lang.ProcessBuilder({'cmd', '/c', 'echo', 'hacked'}).start()";
+        EvaluationContext safeContext = buildSafeContext();
+
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression(maliciousSpel).getValue(safeContext);
+        }, "SimpleEvaluationContext 应拒绝 new 构造器调用");
+    }
+
+    @Test
+    @DisplayName("[修复后-安全验证] SimpleEvaluationContext 拒绝 getClass() 反射链调用")
+    void testSimpleContext_BlocksReflection() {
+        // 通过 getClass().forName() 反射获取 Runtime 的攻击路径
+        String maliciousSpel = "#param.getClass().forName('java.lang.Runtime')" +
+                ".getMethod('exec', T(String)).invoke(" +
+                "#param.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null), 'calc')";
+        EvaluationContext safeContext = buildSafeContext();
+
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression(maliciousSpel).getValue(safeContext);
+        }, "SimpleEvaluationContext 应拒绝反射链攻击");
+    }
+
+    // =====================================================
+    // 第三组：验证正常业务 SpEL 表达式在修复后仍然正常工作
+    // =====================================================
+
+    @Test
+    @DisplayName("[修复后-功能验证] SimpleEvaluationContext 允许正常的变量引用 #param")
+    void testSimpleContext_AllowsVariableReference() {
+        String normalSpel = "#param";
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression(normalSpel).getValue(safeContext);
+        assertEquals("normalValue", result, "正常的变量引用 #param 应正常工作");
+    }
+
+    @Test
+    @DisplayName("[修复后-功能验证] SimpleEvaluationContext 允许正常的返回值变量引用 #$")
+    void testSimpleContext_AllowsReturnValueReference() {
+        String normalSpel = "#$";
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression(normalSpel).getValue(safeContext);
+        assertEquals("returnValue", result, "返回值变量引用 #$ 应正常工作");
+    }
+
+    // =====================================================
+    // 第四组：forReadWriteDataBinding 场景下的方法调用验证
+    // 验证允许对象方法调用（get/非get），同时高危操作仍被阻止
+    // =====================================================
+
+    // --- 4.1 getter 方法调用 ---
+
+    @Test
+    @DisplayName("[方法调用-getter] 允许调用 getId()")
+    void testSimpleContext_AllowsGetId() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.getId()").getValue(safeContext);
+        assertEquals(1001L, result);
+    }
+
+    @Test
+    @DisplayName("[方法调用-getter] 允许调用 getName()")
+    void testSimpleContext_AllowsGetName() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.getName()").getValue(safeContext);
+        assertEquals("test_template", result);
+    }
+
+    @Test
+    @DisplayName("[方法调用-getter] 允许调用 getTags() 并获取集合")
+    void testSimpleContext_AllowsGetTags() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.getTags()").getValue(safeContext);
+        assertNotNull(result);
+        assertTrue(result instanceof List);
+        assertEquals(3, ((List<?>) result).size());
+    }
+
+    @Test
+    @DisplayName("[方法调用-getter] 允许通过属性语法访问（等价于 getter）")
+    void testSimpleContext_AllowsPropertyAccess() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        // 属性语法 #resource.name 等价于 #resource.getName()
+        Object result = parser.parseExpression("#resource.name").getValue(safeContext);
+        assertEquals("test_template", result);
+    }
+
+    // --- 4.2 非 get 开头的业务方法调用 ---
+
+    @Test
+    @DisplayName("[方法调用-非getter] 允许调用 toUpperName() —— 无参非get方法")
+    void testSimpleContext_AllowsToUpperName() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.toUpperName()").getValue(safeContext);
+        assertEquals("TEST_TEMPLATE", result);
+    }
+
+    @Test
+    @DisplayName("[方法调用-非getter] 允许调用 formatDisplay(prefix) —— 带参非get方法")
+    void testSimpleContext_AllowsFormatDisplay() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.formatDisplay('View ')").getValue(safeContext);
+        assertEquals("View [test_template](1001)", result);
+    }
+
+    @Test
+    @DisplayName("[方法调用-非getter] 允许调用 containsTag(tag) —— 返回boolean的非get方法")
+    void testSimpleContext_AllowsContainsTag() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.containsTag('production')").getValue(safeContext);
+        assertEquals(true, result);
+
+        Object result2 = parser.parseExpression("#resource.containsTag('nonexistent')").getValue(safeContext);
+        assertEquals(false, result2);
+    }
+
+    @Test
+    @DisplayName("[方法调用-非getter] 允许调用 countTags() —— 返回int的非get方法")
+    void testSimpleContext_AllowsCountTags() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.countTags()").getValue(safeContext);
+        assertEquals(3, result);
+    }
+
+    // --- 4.3 集合上的方法调用与投影 ---
+
+    @Test
+    @DisplayName("[方法调用-集合] 允许调用 List.size()")
+    void testSimpleContext_AllowsListSize() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resources.size()").getValue(safeContext);
+        assertEquals(3, result);
+    }
+
+    @Test
+    @DisplayName("[方法调用-集合] 允许对集合元素调用非get方法（链式：get+toUpperName）")
+    void testSimpleContext_AllowsChainedMethodOnListElement() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        // 访问第一个元素并调用非get方法
+        Object result = parser.parseExpression("#resources[0].toUpperName()").getValue(safeContext);
+        assertEquals("RES_A", result);
+    }
+
+    @Test
+    @DisplayName("[方法调用-集合] 允许 String.toString() 等 Object 基础方法")
+    void testSimpleContext_AllowsToString() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        Object result = parser.parseExpression("#resource.getId().toString()").getValue(safeContext);
+        assertEquals("1001", result);
+    }
+
+    // --- 4.4 forReadWriteDataBinding 下高危操作仍被阻止 ---
+
+    @Test
+    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝 T() 类型引用")
+    void testReadWriteContext_StillBlocksTypeReference() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression("T(java.lang.Runtime).getRuntime().exec('calc')").getValue(safeContext);
+        });
+    }
+
+    @Test
+    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝 new 构造器")
+    void testReadWriteContext_StillBlocksConstructor() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression("new java.lang.ProcessBuilder({'cmd'}).start()").getValue(safeContext);
+        });
+    }
+
+    @Test
+    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝 getClass() 反射链")
+    void testReadWriteContext_StillBlocksGetClassReflection() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        // 尝试通过业务对象的 getClass() 进入反射链
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression("#resource.getClass().forName('java.lang.Runtime')").getValue(safeContext);
+        });
+    }
+
+    @Test
+    @DisplayName("[方法调用-安全] forReadWriteDataBinding 仍然拒绝通过 String.getClass() 反射")
+    void testReadWriteContext_StillBlocksStringGetClassReflection() {
+        SimpleEvaluationContext safeContext = buildSafeContext();
+
+        assertThrows(SpelEvaluationException.class, () -> {
+            parser.parseExpression("#param.getClass().forName('java.lang.Runtime')").getValue(safeContext);
+        });
+    }
+}


### PR DESCRIPTION
1. 使用 SimpleEvaluationContext 替代 StandardEvaluationContext，禁用类型引用(T())、构造器(new)和静态方法调用，防止 SpEL 注入风险；
2. DefaultAuditRequestProvider不再使用无法信任的Header值作为审计字段；
3. 更新版本为2.0.3。